### PR TITLE
add forgery protection to application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module GearUpBe
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.action_controller.allow_forgery_protection = true
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,5 +66,5 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  config.action_cable.disable_request_forgery_protection = true
 end


### PR DESCRIPTION
This PR adds `config.action_cable.disable_request_forgery_protection = true` to application.rb.  It also uncommented the same line in config/environments/development.rb.